### PR TITLE
Adding support for paste and autofill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+* Supports auto-fill and past of codes.
+
+### Fixed
+
+* Fixed crash which occurs when using iOS 12's security code auto-fill feature.
+* Corrected Typos in Readme/Changelog
+
 ## [v0.4.1] - 2018-02-09
 
 ### Fixed
@@ -21,8 +32,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-* New prop `checkPinCode`(optionnal). Called to check pin code (`code` prop is not used if `checkPinCode` prop is present)
-* New prop `obfuscation` (optionnal). Obfuscate code if set to true
+* New prop `checkPinCode`(optional). Called to check pin code (`code` prop is not used if `checkPinCode` prop is present)
+* New prop `obfuscation` (optional). Obfuscate code if set to true
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # react-native-pin-code
 
-![last release](https://badgen.net/npm/v/react-native-pin-code) ![monthly download](https://badgen.net/npm/dm/react-native-pin-code) ![licence](https://badgen.net/github/license/gkueny/react-native-pin-code)
+![last release](https://badgen.net/npm/v/react-native-pin-code) ![monthly download](https://badgen.net/npm/dm/react-native-pin-code) ![license](https://badgen.net/github/license/gkueny/react-native-pin-code)
 
 A simple pin code component
 

--- a/pin-code.js
+++ b/pin-code.js
@@ -46,7 +46,8 @@ class CodePin extends Component {
   }
 
   focus(id) {
-    this.textInputsRefs[id].focus();
+    // Check to ensure that input exists. This is important in the case of autofill.
+    if(this.textInputsRefs[id]) this.textInputsRefs[id].focus();
   }
 
   isFocus(id) {
@@ -62,10 +63,27 @@ class CodePin extends Component {
 
   handleEdit(number, id) {
     let newCode = this.state.code.slice();
-    newCode[id] = number;
+
+    // Detecting if the entire code has been pasted or autofilled into
+    // the first field.
+    const hasAutofilled = number.length > 1 &&
+                          number.length === this.props.number &&
+                          id === 0;
+
+    if(hasAutofilled){
+      newCode = number.split('');
+
+      // Need to update state so UI updates.
+      this.setState({
+        code: newCode,
+        edit: this.props.number - 1
+      });
+    } else {
+      newCode[id] = number[0];
+    }
 
     // User filling the last pin ?
-    if (id === this.state.number - 1) {
+    if (id === this.state.number - 1 || hasAutofilled) {
       this.focus(0);
 
       // App pass a checkPinCode function
@@ -149,6 +167,7 @@ class CodePin extends Component {
           onChangeText={text => this.handleEdit(text, id)}
           onFocus={() => this.isFocus(id)}
           value={value}
+          maxLength={id === 0 ? this.props.number : 1}
           style={[codePinStyles.pin, pinStyle]}
           returnKeyType={'done'}
           autoCapitalize={'sentences'}


### PR DESCRIPTION
This PR is the first attempt at a solution for #12, preventing a crash when using the new security code auto-fill functionality which ships in iOS 12 and adding support for pasting codes.

I'm assuming a code is likely being auto-filled if the first field has focus, and the length is equal to the `number` prop.

I also noticed it was possible to get into a state where a code can have extra digits (e.g. `['1', '22', '3', '4']` so added code to guard around this.

Not perfect, but resolves the crashing bug, potentially may extend this later.