### PR TITLE
Underlines are no longer drawn on Android

### DIFF
--- a/pin-code.js
+++ b/pin-code.js
@@ -155,6 +155,7 @@ class CodePin extends Component {
           autoCorrect={false}
           autoFocus={id === 0 && this.props.autoFocusFirst}
           onKeyPress={this.onKeyPress}
+          underlineColorAndroid={'transparent'}
           {...props}
         />
       );


### PR DESCRIPTION
The underlines for the text input are currently drawn on Android. 
This pull request makes them transparent such that they are no longer visible. 